### PR TITLE
[62] MCPERSON-2136: add option to include parent in match

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ module.exports = function (options) {
     options = assign({
         el : undefined,
         parent: document,
-        filter: undefined
+        filter: undefined,
+        matchParent: false
     }, options);
     curNode = options.el;
-    while(
+    while (
         curNode &&
         curNode !== document &&
         curNode !== options.parent
@@ -18,5 +19,8 @@ module.exports = function (options) {
             return curNode;
         }
         curNode = curNode.parentNode;
+    }
+    if (options.matchParent && curNode.matches(options.filter)) {
+        return curNode;
     }
 };

--- a/readme.md
+++ b/readme.md
@@ -10,3 +10,16 @@ npm install --save bubble-match
 ```js
 const bubbleMatch = require('bubble-match');
 ```
+
+##documentation:
+#### el
+bubble-match will start searching for a matching element with the element passed through `options.el`
+
+### parent
+bubble-match will search up to, but not include, `options.parent` unless `matchParent: true` is passed in
+
+#### matchParent
+if `true`, bubble-match will include `options.parent` in its search for a matching element
+
+### filter
+selector criteria for matching element

--- a/test/specs.js
+++ b/test/specs.js
@@ -40,4 +40,30 @@ describe("bubble-match", function () {
             filter: '.doesnotmatch'
         }), undefined);
     });
+    it("should evaluate the parent node when finding a matching el if options.matchParent is true", function () {
+        // matchParent: false
+        assert.equal(bubbleMatch({
+            parent: bar,
+            el: child,
+            filter: '.bar',
+            matchParent: false
+        }), undefined);
+
+        // matchParent: true
+        assert.equal(bubbleMatch({
+            parent: bar,
+            el: child,
+            filter: '.bar',
+            matchParent: true
+        }), bar);
+
+        // filter: doesnotmatch
+        assert.equal(bubbleMatch({
+            parent: bar,
+            el: child,
+            filter: '.doesnotmatch',
+            matchParent: true
+        }), undefined);
+
+    });
 });


### PR DESCRIPTION
The issue is that before bubbleMatch was refactored and abstracted into its own package, [the former implementation of bubbleMatch](https://github.com/antialias/bunsen/commit/efc353e73b3e014dad70261db70dd64426ea8b32) would return the child/parent node when the child and parent were the same. Since the new implementation does not, pancake expansion is broken because [bubbleMatch is returning undefined here](https://github.com/1stdibs/bunsen/blob/master/components/messageCenter/MessageSummary/MessageSummary-view.js#L133), and the view isn't being updated to its next state when a user clicks on the pancaked message. 

Alternatively -- instead of making this change to bubbleMatch, I could update the logic in the `MessageSummary-view`.
